### PR TITLE
Customize to ignore schema attribute and add special operation tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Hex license](https://img.shields.io/hexpm/l/soap.svg?style=flat)](https://hex.pm/packages/soap)
 [![Hex downloads](https://img.shields.io/hexpm/dt/soap.svg?style=flat)](https://hex.pm/packages/soap)
 
-SOAP client for Elixir programming language
+SOAP client for Elixir programming language (MIRS)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Configure version of SOAP protocol. Supported versions `1.1`(default) and `1.2`.
 config :soap, :globals, 
         version: "1.1",
         ignore_schema_attribute: "yes", # yes or no
+        allow_soap_action_null: false, # true or false
         special_operation_tag: "xxx:",
         custom_namespaces: %{"xmlns:tem" => "http://tempuri.org/"},
         additional_headers: [{"more_header1","value1"}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ end
 
 Configure version of SOAP protocol. Supported versions `1.1`(default) and `1.2`.
 ```elixir
-config :soap, :globals, version: "1.1"
+config :soap, :globals, 
+        version: "1.1",
+        ignore_schema_attribute: "yes", # yes or no
+        special_operation_tag: "xxx:",
+        custom_namespaces: %{"xmlns:tem" => "http://tempuri.org/"},
+        additional_headers: [{"more_header1","value1"}
+                             {"more_header2","value2"}]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Hex license](https://img.shields.io/hexpm/l/soap.svg?style=flat)](https://hex.pm/packages/soap)
 [![Hex downloads](https://img.shields.io/hexpm/dt/soap.svg?style=flat)](https://hex.pm/packages/soap)
 
-SOAP client for Elixir programming language (MIRS)
+SOAP client for Elixir programming language
 
 ## Installation
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,4 +28,3 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
-config :soap, :globals, version: "1.1"

--- a/lib/soap/request/headers.ex
+++ b/lib/soap/request/headers.ex
@@ -29,7 +29,11 @@ defmodule Soap.Request.Headers do
   @spec base_headers(String.t()) :: list()
   defp base_headers(soap_action) do
     base = [{"SOAPAction", soap_action}, {"Content-Type", "text/xml;charset=utf-8"}]
-    add = Application.fetch_env!(:soap, :globals)[:additional_headers]
-    base ++ add
+    case is_list(Application.fetch_env!(:soap, :globals)[:additional_headers]) do
+    	false ->
+		base
+        _ ->
+    		base ++ Application.fetch_env!(:soap, :globals)[:additional_headers]
+    end
   end
 end

--- a/lib/soap/request/headers.ex
+++ b/lib/soap/request/headers.ex
@@ -28,6 +28,8 @@ defmodule Soap.Request.Headers do
 
   @spec base_headers(String.t()) :: list()
   defp base_headers(soap_action) do
-    [{"SOAPAction", soap_action}, {"Content-Type", "text/xml;charset=utf-8"}]
+    base = [{"SOAPAction", soap_action}, {"Content-Type", "text/xml;charset=utf-8"}]
+    add = Application.fetch_env!(:soap, :globals)[:additional_headers]
+    base ++ add
   end
 end

--- a/lib/soap/request/params.ex
+++ b/lib/soap/request/params.ex
@@ -193,7 +193,7 @@ defmodule Soap.Request.Params do
       |> get_action_with_namespace(operation)
       |> prepare_action_tag(operation)
 
-    [element(action_tag, action_tag_attributes, body)]
+    [element(Application.fetch_env!(:soap, :globals)[:special_operation_tag]<>action_tag, action_tag_attributes, body)]
   end
 
   @spec add_header_part_tag_wrapper(list(), map(), String.t()) :: list()

--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -207,12 +207,15 @@ defmodule Soap.Wsdl do
 
   @spec get_schema_attributes(String.t()) :: map()
   defp get_schema_attributes(wsdl) do
-    wsdl
-    |> xpath(
-      ~x"//*[local-name() = 'schema']",
-      target_namespace: ~x"./@targetNamespace"s,
-      element_form_default: ~x"./@elementFormDefault"s
-    )
+    case Application.fetch_env!(:soap, :globals)[:ignore_schema_attribute] do
+     "yes" -> []
+     _ -> wsdl
+	    |> xpath(
+	      ~x"//*[local-name() = 'schema']",
+	      target_namespace: ~x"./@targetNamespace"s,
+	      element_form_default: ~x"./@elementFormDefault"s
+	    )
+    end
   end
 
   defp soap_version, do: Application.fetch_env!(:soap, :globals)[:version]

--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -153,7 +153,9 @@ defmodule Soap.Wsdl do
       |> xpath(~x".", name: ~x"./@name"s, soap_action: ~x"./#{ns("operation", soap_ns)}/@soapAction"s)
       |> Map.put(:input, get_operation_input(node, protocol_ns, soap_ns))
     end)
-    |> Enum.reject(fn x -> x[:soap_action] == "" end)
+    |> Enum.reject(fn x -> Application.fetch_env!(:soap, :globals)[:allow_soap_action_null]==false end)
+    #|> Enum.reject(fn x -> x[:soap_action] == "" and Application.fetch_env!(:soap, :globals)[:allow_soap_action_null]==false end)
+
   end
 
   defp get_operation_input(element, protocol_ns, soap_ns) do


### PR DESCRIPTION
I've adjust the code to more support WSDL. Some of my vendors WSDL not able to parse schema attribute and need to put a tag before operation name.

Example: 

config :soap, :globals,
        version: "1.1",
        ignore_schema_attribute: "no",
        special_operation_tag: "tem:"

If you feel this help you can merge it.