### PR TITLE
Allow empty soap actions on operations

### DIFF
--- a/lib/soap.ex
+++ b/lib/soap.ex
@@ -55,7 +55,10 @@ defmodule Soap do
 
   - `path`: Path for wsdl file.
   - `type`: Atom that represents the type of path for WSDL file. Can be `:file` or `url`. Default: `:file`.
-  - `opts`: HTTPoison options or `:soap_version`.
+  - `opts`: any options for `HTTPoison.Request` and the following parsing options:
+
+    * `:soap_version` - Specifies SOAP version for parsing.
+    * `:allow_empty_soap_actions` - Allows SOAP operations with an empty `soapAction` attribute. This may be required for APIs that do not set a `soapAction` for each operation.
 
   ## Examples
 

--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -35,7 +35,7 @@ defmodule Soap.Wsdl do
       namespaces: get_namespaces(wsdl, schema_namespace, protocol_namespace),
       endpoint: endpoint,
       complex_types: get_complex_types(wsdl, schema_namespace, protocol_namespace),
-      operations: get_operations(wsdl, protocol_namespace, soap_namespace),
+      operations: get_operations(wsdl, protocol_namespace, soap_namespace, opts),
       schema_attributes: get_schema_attributes(wsdl),
       validation_types: get_validation_types(wsdl, file_path, protocol_namespace, schema_namespace, endpoint),
       soap_version: soap_version(opts),
@@ -160,7 +160,7 @@ defmodule Soap.Wsdl do
     end)
   end
 
-  defp get_operations(wsdl, protocol_ns, soap_ns) do
+  defp get_operations(wsdl, protocol_ns, soap_ns, opts) do
     wsdl
     |> xpath(~x"//#{ns("definitions", protocol_ns)}/#{ns("binding", protocol_ns)}/#{ns("operation", protocol_ns)}"l)
     |> Enum.map(fn node ->
@@ -168,7 +168,7 @@ defmodule Soap.Wsdl do
       |> xpath(~x".", name: ~x"./@name"s, soap_action: ~x"./#{ns("operation", soap_ns)}/@soapAction"s)
       |> Map.put(:input, get_operation_input(node, protocol_ns, soap_ns))
     end)
-    |> Enum.reject(fn x -> x[:soap_action] == "" end)
+    |> Enum.reject(fn x -> x[:soap_action] == "" && !opts[:allow_empty_soap_actions] end)
   end
 
   defp get_operation_input(element, protocol_ns, soap_ns) do

--- a/test/fixtures/wsdl/StockServiceMinusAction.wsdl
+++ b/test/fixtures/wsdl/StockServiceMinusAction.wsdl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions name="StockQuote" targetNamespace="http://example.com/stockquote.wsdl" xmlns:tns="http://example.com/stockquote.wsdl" xmlns:xsd1="http://example.com/stockquote.xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns="http://schemas.xmlsoap.org/wsdl/">
+  <types>
+    <schema targetNamespace="http://example.com/stockquote.xsd" xmlns="http://www.w3.org/2001/XMLSchema">
+      <element name="TradePriceRequest">
+        <complexType>
+          <all>
+            <element name="tickerSymbol" type="string"/>
+          </all>
+        </complexType>
+      </element>
+      <element name="TradePrice">
+        <complexType>
+          <all>
+            <element name="price" type="float"/>
+          </all>
+        </complexType>
+      </element>
+    </schema>
+  </types>
+  <message name="GetLastTradePriceInput">
+    <part name="body" element="xsd1:TradePriceRequest"/>
+  </message>
+  <message name="GetLastTradePriceOutput">
+    <part name="body" element="xsd1:TradePrice"/>
+  </message>
+  <portType name="StockQuotePortType">
+    <operation name="GetLastTradePrice">
+      <input message="tns:GetLastTradePriceInput"/>
+      <output message="tns:GetLastTradePriceOutput"/>
+    </operation>
+  </portType>
+  <binding name="StockQuoteSoapBinding" type="tns:StockQuotePortType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="GetLastTradePrice">
+      <soap:operation />
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="StockQuoteService">
+    <documentation>My first service</documentation>
+    <port name="StockQuotePort" binding="tns:StockQuoteBinding">
+      <soap:address location="http://example.com/stockquote"/>
+    </port>
+  </service>
+</definitions>

--- a/test/soap/wsdl_test.exs
+++ b/test/soap/wsdl_test.exs
@@ -364,4 +364,13 @@ defmodule Soap.WsdlTest do
     {:ok, parsed_wsdl} = Wsdl.parse_from_file(wsdl_path)
     assert parsed_wsdl.schema_attributes == %{}
   end
+
+  test "#parse WSDL allowing blank soap actions" do
+    wsdl_path = Fixtures.get_file_path("wsdl/StockServiceMinusAction.wsdl")
+    {:ok, parsed_wsdl} = Wsdl.parse_from_file(wsdl_path)
+    assert Enum.empty?(parsed_wsdl.operations) == true
+
+    {:ok, parsed_wsdl} = Wsdl.parse_from_file(wsdl_path, allow_empty_soap_actions: true)
+    assert Enum.empty?(parsed_wsdl.operations) == false
+  end
 end


### PR DESCRIPTION
Soap actions are allowed to be blank when parsing a WSDL when the optional parameter `allow_blank_soap_action: true` is passed as an option when calling `Soap.init_model/3`. Additionally, a test with fixture is included to ensure the behavior of the option is honored when the param is included and omitted. 

Fixes #67 and includes a test that ensures current behavior if the parameter isn't included when parsing the WSDL.