### PR TITLE
Speeding up initialization on large schemas

### DIFF
--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -26,6 +26,8 @@ defmodule Soap.Wsdl do
 
   @spec parse(String.t(), String.t(), map()) :: {:ok, map()}
   def parse(wsdl, file_path, opts \\ []) do
+    wsdl = SweetXml.parse(wsdl)
+
     protocol_namespace = get_protocol_namespace(wsdl)
     soap_namespace = get_soap_namespace(wsdl, opts)
     schema_namespace = get_schema_namespace(wsdl)


### PR DESCRIPTION
This change makes XML parser do it's job eagerly on the whole document, instead of passing the string around and parse it over and over. In particular example of a 3Mb schema from Workday API it reduces init time from 80 to 2 seconds.