### PR TITLE
Pass HTTP options to XSD and add ability to skip XSD fetching

### DIFF
--- a/lib/soap.ex
+++ b/lib/soap.ex
@@ -71,6 +71,7 @@ defmodule Soap do
     * `:allow_empty_soap_actions` - Allows SOAP operations with an empty
       `soapAction` attribute. This may be required for APIs that do not set a
       `soapAction` for each operation.
+    * `:skip_type_imports` - Prevents fetching external XSDs for importing types.
 
   ## Examples
 

--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -37,7 +37,7 @@ defmodule Soap.Wsdl do
       complex_types: get_complex_types(wsdl, schema_namespace, protocol_namespace),
       operations: get_operations(wsdl, protocol_namespace, soap_namespace, opts),
       schema_attributes: get_schema_attributes(wsdl),
-      validation_types: get_validation_types(wsdl, file_path, protocol_namespace, schema_namespace, endpoint),
+      validation_types: get_validation_types(wsdl, file_path, protocol_namespace, schema_namespace, endpoint, opts),
       soap_version: soap_version(opts),
       messages: get_messages(wsdl, protocol_namespace)
     }
@@ -105,8 +105,8 @@ defmodule Soap.Wsdl do
     )
   end
 
-  @spec get_validation_types(String.t(), String.t(), String.t(), String.t(), String.t()) :: map()
-  def get_validation_types(wsdl, file_path, protocol_ns, schema_ns, endpoint) do
+  @spec get_validation_types(String.t(), String.t(), String.t(), String.t(), String.t(), keyword()) :: map()
+  def get_validation_types(wsdl, file_path, protocol_ns, schema_ns, endpoint, opts \\ []) do
     Map.merge(
       Type.get_complex_types(
         wsdl,
@@ -114,7 +114,7 @@ defmodule Soap.Wsdl do
       ),
       wsdl
       |> get_full_paths(file_path, protocol_ns, schema_ns, endpoint)
-      |> get_imported_types
+      |> get_imported_types(opts)
       |> Enum.reduce(%{}, &Map.merge(&2, &1))
     )
   end
@@ -149,11 +149,11 @@ defmodule Soap.Wsdl do
     end
   end
 
-  @spec get_imported_types(list()) :: list(map())
-  defp get_imported_types(xsd_paths) do
+  @spec get_imported_types(list(), keyword()) :: list(map())
+  defp get_imported_types(xsd_paths, opts) do
     xsd_paths
     |> Enum.map(fn xsd_path ->
-      case Xsd.parse(xsd_path) do
+      case Xsd.parse(xsd_path, opts) do
         {:ok, xsd} -> xsd.complex_types
         _ -> %{}
       end

--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -151,6 +151,16 @@ defmodule Soap.Wsdl do
 
   @spec get_imported_types(list(), keyword()) :: list(map())
   defp get_imported_types(xsd_paths, opts) do
+    opts
+    |> Keyword.get(:skip_type_imports, false)
+    |> case do
+      true -> %{}
+      _ -> do_get_imported_types(xsd_paths, opts)
+    end
+  end
+
+  @spec do_get_imported_types(list(), keyword()) :: list(map())
+  defp do_get_imported_types(xsd_paths, opts) do
     xsd_paths
     |> Enum.map(fn xsd_path ->
       case Xsd.parse(xsd_path, opts) do


### PR DESCRIPTION
This PR includes two changes:
- Pass along request options to XSD.parse, which enables SSL options to be passed along
- Add ability to skip XSD fetching

The ability to skip XSD fetching is helpful when the endpoint has an invalid XSD and we have no control over getting the issue corrected.