### PR TITLE
adds ability to pass arbitrary url in opts for testing

### DIFF
--- a/lib/soap.ex
+++ b/lib/soap.ex
@@ -65,6 +65,9 @@ defmodule Soap do
   - `path`: Path for wsdl file.
   - `type`: Atom that represents the type of path for WSDL file. Can be `:file`
     or `url`. Default: `:file`.
+  - `endpoint`: Endpoint to be used for the request.  Defaults to the endpoint
+    specified in the WSDL file.  Useful for (e.g.) sending a request to a mock
+    server during testing.
   - `opts`: any options for `HTTPoison.Request` and the following parsing options:
 
     * `:soap_version` - Specifies SOAP version for parsing.

--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -31,7 +31,7 @@ defmodule Soap.Wsdl do
     protocol_namespace = get_protocol_namespace(wsdl)
     soap_namespace = get_soap_namespace(wsdl, opts)
     schema_namespace = get_schema_namespace(wsdl)
-    endpoint = opts |> Keyword.get(:endpoint, get_endpoint(wsdl, protocol_namespace, soap_namespace))
+    endpoint = Keyword.get(opts, :endpoint, get_endpoint(wsdl, protocol_namespace, soap_namespace))
 
     parsed_response = %{
       namespaces: get_namespaces(wsdl, schema_namespace, protocol_namespace),

--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -31,7 +31,7 @@ defmodule Soap.Wsdl do
     protocol_namespace = get_protocol_namespace(wsdl)
     soap_namespace = get_soap_namespace(wsdl, opts)
     schema_namespace = get_schema_namespace(wsdl)
-    endpoint = get_endpoint(wsdl, protocol_namespace, soap_namespace)
+    endpoint = opts |> Keyword.get(:endpoint, get_endpoint(wsdl, protocol_namespace, soap_namespace))
 
     parsed_response = %{
       namespaces: get_namespaces(wsdl, schema_namespace, protocol_namespace),


### PR DESCRIPTION
In order to support testing SOAP calls against a mock server, it's helpful to be able to override the defined endpoint.  This PR adds the ability to pass in an endpoint as an option.