### PR TITLE
soap_version/0 now loads :version 1.1 by default

### DIFF
--- a/lib/soap/response/parser.ex
+++ b/lib/soap/response/parser.ex
@@ -105,5 +105,17 @@ defmodule Soap.Response.Parser do
   defp apply_namespace_to_tag("", tag), do: tag
   defp apply_namespace_to_tag(env_namespace, tag), do: env_namespace <> ":" <> tag
 
-  defp soap_version, do: Application.fetch_env!(:soap, :globals)[:version]
+  defp soap_version do
+    case Application.fetch_env(:soap, :globals) do
+      :error ->
+        "1.1"
+
+      {:ok, content} ->
+        if :version in Keyword.keys(content) do
+          content[:version]
+        else
+          "1.1"
+        end
+    end
+  end
 end


### PR DESCRIPTION
In partial response to [issue 88](https://github.com/elixir-soap/soap/issues/88), I noticed that Soap fails completely if my application does not define `config :soap, :globals` in its `config/config.exs`, even though a) HTTPoison is the default client and b) version 1.1 is claimed in the documentation to be the default.

Applications using a dependency that itself depends on Soap should not need to add anything to their `config/config.exs`, especially if what is expected to be defined therein has a sane default value (version 1.1, and HTTPoison), I redefined `soap_version/0` to first see if it can fetch its configuration; if not, it gracefully returns the (default, according to the docs) version 1.1.

Note that the test suite of Soap still assumes that `config/config.exs` contains a configuration. Removing these lines from it makes tests fail. It might be a good idea to get rid of this caveat entirely, and follow the official recommendation to [avoid application configuration for libraries](https://hexdocs.pm/elixir/library-guidelines.html#avoid-application-configuration).